### PR TITLE
feat: narrow down `ResilienceEvents` interface

### DIFF
--- a/src/interfaces/resilience-events.interface.ts
+++ b/src/interfaces/resilience-events.interface.ts
@@ -2,8 +2,6 @@ import { ResilienceEventType } from '../enum';
 import { BaseCommand } from '../commands';
 
 export interface ResilienceEvents {
-	[key: string | symbol]: any[];
-
 	[ResilienceEventType.Emit]: [command: BaseCommand];
 	[ResilienceEventType.Success]: [command: BaseCommand];
 	[ResilienceEventType.Failure]: [command: BaseCommand];

--- a/src/resilience.event-bus.ts
+++ b/src/resilience.event-bus.ts
@@ -13,12 +13,12 @@ export class ResilienceEventBus {
 	private readonly emitter = new EventEmitter();
 
 	public on<K extends keyof ResilienceEvents>(event: K, fn: (args: ResilienceEvents[K]) => void) {
-		this.emitter.on(event as string, (...args) => fn.call(this, args));
+		this.emitter.on(event, (...args) => fn.call(this, args));
 		return this;
 	}
 
 	public emit<K extends keyof ResilienceEvents>(event: K, ...args: ResilienceEvents[K]) {
-		this.emitter.emit(event as string, ...args);
+		this.emitter.emit(event, ...args);
 		return this;
 	}
 }

--- a/test/commands/resilience.command.spec.ts
+++ b/test/commands/resilience.command.spec.ts
@@ -1,4 +1,4 @@
-import { ResilienceCommand, ResilienceEventBus } from '../../src';
+import { ResilienceCommand, ResilienceEventBus, ResilienceEventType } from '../../src';
 import { retryStrategy } from './fixtures/strategy.fixture';
 
 class TestCommand extends ResilienceCommand {
@@ -42,7 +42,7 @@ describe('Resilience Command', () => {
 	});
 
 	it('should be able to retry a promise', async () => {
-		eventBus.on('success', callback);
+		eventBus.on(ResilienceEventType.Success, callback);
 
 		const value = await command.execute();
 
@@ -52,7 +52,7 @@ describe('Resilience Command', () => {
 
 	it('should emit the failure', async () => {
 		command.setIsError(true);
-		eventBus.on('failure', callback);
+		eventBus.on(ResilienceEventType.Failure, callback);
 
 		try {
 			await command.execute();


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Hi,

Thanks for the amazing library.
If I understand correctly, the `ResilienceEvents` interface needs to be changed to allow for tighter type checking.

**Status and versioning classification:**
2.1.3(latest)

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
